### PR TITLE
feat: add dark mode toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,5 +16,8 @@
   Fork me? Fork you, @octocat!
 </p>
 
+<button id="theme-toggle">Toggle dark mode</button>
+<script src="script.js"></script>
+
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,3 @@
+document.getElementById('theme-toggle').addEventListener('click', () => {
+  document.body.classList.toggle('dark-mode');
+});

--- a/styles.css
+++ b/styles.css
@@ -15,3 +15,8 @@ p {
   margin: 50px auto;
   font: 30px Monaco,"Courier New","DejaVu Sans Mono","Bitstream Vera Sans Mono",monospace;
 }
+
+.dark-mode {
+  background: #222;
+  color: #eee;
+}


### PR DESCRIPTION
## Summary
- add client-side script to toggle dark mode on button click
- wire up index page with toggle button and script
- style dark mode with darker background and light text

## Testing
- `npm test` (fails: Could not read package.json)

------
https://chatgpt.com/codex/tasks/task_e_68b18546f2408329b8ce8c49dca09e2b